### PR TITLE
[automation] [fix] updated prettier to automatically determine line ending based on env

### DIFF
--- a/pilot-website/src/.prettierrc
+++ b/pilot-website/src/.prettierrc
@@ -16,5 +16,6 @@
   "vueIndentScriptAndStyle": false,
   "printWidth": 140,
   "tabWidth": 2,
-  "rangeStart": 0
+  "rangeStart": 0,
+  "endOfLine": "auto"
 }


### PR DESCRIPTION
updated .`prettierrc` to automatically determine line ending based on env. This was causing lint issues as seen and discussed with @le000222 resulting in lint errors on the screen.

This should conclude our linting and formatting automation.